### PR TITLE
new doctype

### DIFF
--- a/express/views/layout.jade
+++ b/express/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype
 html
   head
     title= title + ' | MC API Node.js Example'


### PR DESCRIPTION
`doctype 5` is deprecated, you must now use `doctype html`